### PR TITLE
Fix syntax for passenv in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,13 @@ commands =
 
 whitelist_externals = bash
                       find
-passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
+passenv =
+    http_proxy
+    HTTP_PROXY
+    https_proxy
+    HTTPS_PROXY
+    no_proxy
+    NO_PROXY
 
 [testenv:pep8]
 basepython = python3


### PR DESCRIPTION
Currently, the following error is reported:

"tox.tox_env.errors.Fail: pass_env values cannot contain whitespace, use
comma to have multiple values in a single line, invalid values found
'http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY'"
