### PR TITLE
py312

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,13 @@ commands =
 
 whitelist_externals = bash
                       find
-passenv = http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY
+passenv =
+    http_proxy
+    HTTP_PROXY
+    https_proxy
+    HTTPS_PROXY
+    no_proxy
+    NO_PROXY
 
 [testenv:pep8]
 basepython = python3


### PR DESCRIPTION
- **Fix syntax for passenv in tox.ini**
- **Python 3.12: Use assertRaisesRegex instead of assertRaisesRegexp**
