### PR TITLE
Python 3.12: Use assertRaisesRegex instead of assertRaisesRegexp

### DIFF
--- a/rbd_iscsi_client/tests/test_client_request.py
+++ b/rbd_iscsi_client/tests/test_client_request.py
@@ -118,7 +118,7 @@ class TestRbd_iscsi_client(unittest.TestCase):
         with mock.patch('requests.request', retest, create=True):
             # Test requests exception
             retest.side_effect = requests.exceptions.SSLError
-            self.assertRaisesRegexp(exceptions.SSLCertFailed, "failed")
+            self.assertRaisesRegex(exceptions.SSLCertFailed, "failed")
 
     def test_client_timeout_setting(self):
         self.client._http_log_req = mock.Mock()


### PR DESCRIPTION
The latter has been removed in Python3.12[1].

[1] https://docs.python.org/3/whatsnew/3.12.html#id3
